### PR TITLE
chore: Update to latest bootstrap version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   bootstrap:
-    image: ghcr.io/holochain/kitsune2_bootstrap_srv@sha256:02e2d138496c000ebb17d4ace84507870b4f5967ed270d814a8a4e312e8c1c83
+    image: ghcr.io/holochain/kitsune2_bootstrap_srv:v0.0.1-alpha9
     command:
       - kitsune2-bootstrap-srv
       - --production


### PR DESCRIPTION
This was deployed from a PR originally. Now that we've released the container with a tag, update to use the tag. I've already deployed this to the bootstrap server.