### PR TITLE
feat: add dev-test-bootstrap2-iroh-auth deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Built binary
+./network-services

--- a/Pulumi.network-services.yaml
+++ b/Pulumi.network-services.yaml
@@ -12,3 +12,11 @@ config:
   cloudflare:apiToken:
     secure: AAABAFPh7LffxJ9S2r0u9GTA2M5dKok33wA3EsEtRrHD5WALAIDju1ANuvtjsaoxtZ7UpojMifDF7Ndk49zxFXhZozwvzn+/kQJWRhdsNqWmSsr9NA==
   dns:cloudflare-zone-id: 10a5dbacf3bed1ccc671f04e90f4423f
+  dev-test-bootstrap2-iroh-auth:github-client-id:
+    secure: AAABAN1H1r/yf7obDKxdwSxb2WwUuUToyM02adzwa8t1rOdkUrN4OS6Ap4px668m3mmyFw==
+  dev-test-bootstrap2-iroh-auth:github-client-secret:
+    secure: AAABAIC/azyH4dPhe+MTkAaSxQCmD55RvIF+J9ZC8vOPPBi7Y2z86EUaY+JZegi447xP87oF2oT7gKBESJrOiHI/TH6EmLfM
+  dev-test-bootstrap2-iroh-auth:session-secret:
+    secure: AAABALb5ugMJ4AjqbyJFerc+oi2vcH/+VlIfNArUtD1DTO/L246kkts26tMgPgQ3y1EybO5fFnYnuWNkACSXj+kBT4wOyIJ7jvIeIju95O2K/QZpmlVKa5LyoaMQ3ny0bXM1hLFubv9WTOsTmcAFjdmJGOliZDqY
+  dev-test-bootstrap2-iroh-auth:api-tokens:
+    secure: AAABANKXvNC6A1ctMYWDnsepNDMHtaUyqzrJ2TedmgShU4GwcblQ4ZsSLNiGx8CJEAFoxYdX332w8pFmd+Aj0WUWdp4=

--- a/dev-test-bootstrap2-iroh-auth/auth-cloud-init.yaml.tmpl
+++ b/dev-test-bootstrap2-iroh-auth/auth-cloud-init.yaml.tmpl
@@ -1,0 +1,72 @@
+#cloud-config
+
+write_files:
+  - content: |
+      [Container]
+      Image=ghcr.io/holochain/hc_auth_server:v0.1.5
+      Exec=hc-auth-server
+      EnvironmentFile=/opt/auth_srv/auth.env
+      Network=host
+      User=0
+      Volume=/etc/letsencrypt:/etc/letsencrypt:ro
+
+      [Service]
+      Restart=always
+
+      [Install]
+      WantedBy=multi-user.target default.target
+    path: /etc/containers/systemd/auth.container
+    permissions: "0644"
+
+  - content: |
+      GITHUB_CLIENT_ID={{ .GithubClientId }}
+      GITHUB_CLIENT_SECRET={{ .GithubClientSecret }}
+      GITHUB_ORG=EphyraSoftware
+      GITHUB_TEAM=auth
+      HOST=0.0.0.0
+      PORT=443
+      PRODUCTION=true
+      REDIRECT_URI=https://dev-test-auth.holochain.org/ops/oauth-callback
+      SESSION_SECRET={{ .SessionSecret }}
+      MAX_PENDING_REQUESTS=100
+      API_TOKENS={{ .ApiTokens }}
+      REDIS_URL={{ .RedisUrl }}
+      TLS_CERT=/etc/letsencrypt/live/dev-test-auth.holochain.org/fullchain.pem
+      TLS_KEY=/etc/letsencrypt/live/dev-test-auth.holochain.org/privkey.pem
+    path: /opt/auth_srv/auth.env
+    permissions: "0600"
+
+  - content: |
+      #!/bin/bash
+      set -euo pipefail
+
+      # Restart journald so its storage directory matches the machine ID
+      # that cloud-init may have reinitialized.
+      systemctl restart systemd-journald
+
+      apt-get update -y
+      apt-get install -y podman certbot
+
+      max_attempts=30
+      delay=20
+
+      for attempt in $(seq 1 $max_attempts); do
+        echo "Certbot attempt $attempt of $max_attempts..."
+        if certbot certonly --standalone -d dev-test-auth.holochain.org --non-interactive --agree-tos -m contact@holochain.org; then
+          echo "Certificate obtained successfully."
+          systemctl daemon-reload
+          systemctl start auth
+          exit 0
+        fi
+        sleep_for=$((delay * attempt))
+        echo "Certbot failed. Retrying in ${sleep_for}s..."
+        sleep "$sleep_for"
+      done
+
+      echo "Failed to obtain certificate after $max_attempts attempts."
+      exit 1
+    path: /opt/auth_srv/provision-cert.sh
+    permissions: "0755"
+
+runcmd:
+  - /opt/auth_srv/provision-cert.sh

--- a/dev-test-bootstrap2-iroh-auth/bootstrap-cloud-init.yaml
+++ b/dev-test-bootstrap2-iroh-auth/bootstrap-cloud-init.yaml
@@ -1,0 +1,53 @@
+#cloud-config
+
+write_files:
+  - content: |
+      [Container]
+      Image=ghcr.io/holochain/kitsune2_bootstrap_srv_iroh_relay:v0.4.0-dev.6
+      Exec=kitsune2-bootstrap-srv --production --listen [::]:443 --tls-cert /etc/letsencrypt/live/dev-test-bootstrap2-iroh-auth.holochain.org/fullchain.pem --tls-key /etc/letsencrypt/live/dev-test-bootstrap2-iroh-auth.holochain.org/privkey.pem --authentication-hook-server https://dev-test-auth.holochain.org
+      Environment=RUST_LOG=info
+      Network=host
+      Volume=/etc/letsencrypt:/etc/letsencrypt:ro
+
+      [Service]
+      Restart=always
+
+      [Install]
+      WantedBy=multi-user.target default.target
+    path: /etc/containers/systemd/bootstrap.container
+    permissions: "0644"
+
+  - content: |
+      #!/bin/bash
+      set -euo pipefail
+
+      # Restart journald so its storage directory matches the machine ID
+      # that cloud-init may have reinitialized.
+      systemctl restart systemd-journald
+
+      apt-get update -y
+      apt-get install -y podman certbot
+
+      max_attempts=30
+      delay=20
+
+      for attempt in $(seq 1 $max_attempts); do
+        echo "Certbot attempt $attempt of $max_attempts..."
+        if certbot certonly --standalone -d dev-test-bootstrap2-iroh-auth.holochain.org --non-interactive --agree-tos -m contact@holochain.org; then
+          echo "Certificate obtained successfully."
+          systemctl daemon-reload
+          systemctl start bootstrap
+          exit 0
+        fi
+        sleep_for=$((delay * attempt))
+        echo "Certbot failed. Retrying in ${sleep_for}s..."
+        sleep "$sleep_for"
+      done
+
+      echo "Failed to obtain certificate after $max_attempts attempts."
+      exit 1
+    path: /opt/bootstrap_srv/provision-cert.sh
+    permissions: "0755"
+
+runcmd:
+  - /opt/bootstrap_srv/provision-cert.sh

--- a/main.go
+++ b/main.go
@@ -27,6 +27,20 @@ func main() {
 		log.Fatalf("failed to parse hc-auth-iroh-unyt/cloud-init.yaml.tmpl: %s", err)
 	}
 
+	devTestBootstrap2IrohAuthBootstrapCloudInit, err := os.ReadFile("dev-test-bootstrap2-iroh-auth/bootstrap-cloud-init.yaml")
+	if err != nil {
+		log.Fatalf("failed to load dev-test-bootstrap2-iroh-auth/bootstrap-cloud-init.yaml: %s", err)
+	}
+
+	devTestBootstrap2IrohAuthAuthCloudInitBytes, err := os.ReadFile("dev-test-bootstrap2-iroh-auth/auth-cloud-init.yaml.tmpl")
+	if err != nil {
+		log.Fatalf("failed to load dev-test-bootstrap2-iroh-auth/auth-cloud-init.yaml.tmpl: %s", err)
+	}
+	devTestBootstrap2IrohAuthAuthCloudInitTmpl, err := template.New("dev-test-bootstrap2-iroh-auth-auth-cloud-init").Parse(string(devTestBootstrap2IrohAuthAuthCloudInitBytes))
+	if err != nil {
+		log.Fatalf("failed to parse dev-test-bootstrap2-iroh-auth/auth-cloud-init.yaml.tmpl: %s", err)
+	}
+
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		if err := configureDevTestBootstrapSrv(ctx); err != nil {
 			return err
@@ -37,6 +51,10 @@ func main() {
 		}
 
 		if err := configureHcAuthIrohUnyt(ctx, hcAuthIrohUnytCloudInitTmpl); err != nil {
+			return err
+		}
+
+		if err := configureDevTestBootstrap2IrohAuth(ctx, string(devTestBootstrap2IrohAuthBootstrapCloudInit), devTestBootstrap2IrohAuthAuthCloudInitTmpl); err != nil {
 			return err
 		}
 
@@ -175,4 +193,136 @@ func configureHcAuthIrohUnyt(ctx *pulumi.Context, cloudInitTmpl *template.Templa
 		UserData: userData,
 	}, pulumi.IgnoreChanges([]string{"sshKeys", "userData"}))
 	return err
+}
+
+func configureDevTestBootstrap2IrohAuth(ctx *pulumi.Context, bootstrapCloudInit string, authCloudInitTmpl *template.Template) error {
+	cfg := pulumiConfig.New(ctx, "dns")
+	zoneId := cfg.Require("cloudflare-zone-id")
+
+	authCfg := pulumiConfig.New(ctx, "dev-test-bootstrap2-iroh-auth")
+	githubClientId := authCfg.RequireSecret("github-client-id")
+	githubClientSecret := authCfg.RequireSecret("github-client-secret")
+	sessionSecret := authCfg.RequireSecret("session-secret")
+	apiTokens := authCfg.RequireSecret("api-tokens")
+
+	getSshKeysResult, err := digitalocean.GetSshKeys(ctx, &digitalocean.GetSshKeysArgs{}, nil)
+	if err != nil {
+		return err
+	}
+
+	var sshFingerprints []string
+	for _, key := range getSshKeysResult.SshKeys {
+		sshFingerprints = append(sshFingerprints, key.Fingerprint)
+	}
+
+	// Managed Valkey (Redis-compatible) database
+	db, err := digitalocean.NewDatabaseCluster(ctx, "dev-test-auth-db", &digitalocean.DatabaseClusterArgs{
+		Name:      pulumi.String("dev-test-auth-db"),
+		Engine:    pulumi.String("valkey"),
+		Version:   pulumi.String("8"),
+		Size:      pulumi.String("db-s-1vcpu-1gb"),
+		Region:    pulumi.String(digitalocean.RegionFRA1),
+		NodeCount: pulumi.Int(1),
+	})
+	if err != nil {
+		return err
+	}
+
+	// Bootstrap droplet
+	bootstrapDroplet, err := digitalocean.NewDroplet(ctx, "dev-test-bootstrap2-iroh-auth", &digitalocean.DropletArgs{
+		Image:    pulumi.String("ubuntu-24-04-x64"),
+		Name:     pulumi.String("dev-test-bootstrap2-iroh-auth"),
+		Region:   pulumi.String(digitalocean.RegionFRA1),
+		Size:     pulumi.String(digitalocean.DropletSlugDropletS1VCPU2GB),
+		Ipv6:     pulumi.Bool(true),
+		Tags:     pulumi.StringArray{pulumi.String("network-services")},
+		SshKeys:  pulumi.ToStringArray(sshFingerprints),
+		UserData: pulumi.String(bootstrapCloudInit),
+	}, pulumi.IgnoreChanges([]string{"sshKeys"}))
+	if err != nil {
+		return err
+	}
+
+	// Auth droplet with templated cloud-init
+	authUserData := pulumi.All(githubClientId, githubClientSecret, sessionSecret, apiTokens, db.Uri).ApplyT(
+		func(args []interface{}) (string, error) {
+			data := map[string]string{
+				"GithubClientId":     args[0].(string),
+				"GithubClientSecret": args[1].(string),
+				"SessionSecret":      args[2].(string),
+				"ApiTokens":          args[3].(string),
+				"RedisUrl":           args[4].(string),
+			}
+			var buf bytes.Buffer
+			if err := authCloudInitTmpl.Execute(&buf, data); err != nil {
+				return "", err
+			}
+			return buf.String(), nil
+		}).(pulumi.StringOutput)
+
+	authDroplet, err := digitalocean.NewDroplet(ctx, "dev-test-auth", &digitalocean.DropletArgs{
+		Image:    pulumi.String("ubuntu-24-04-x64"),
+		Name:     pulumi.String("dev-test-auth"),
+		Region:   pulumi.String(digitalocean.RegionFRA1),
+		Size:     pulumi.String(digitalocean.DropletSlugDropletS1VCPU2GB),
+		Ipv6:     pulumi.Bool(true),
+		Tags:     pulumi.StringArray{pulumi.String("network-services")},
+		SshKeys:  pulumi.ToStringArray(sshFingerprints),
+		UserData: authUserData,
+	}, pulumi.IgnoreChanges([]string{"sshKeys"}))
+	if err != nil {
+		return err
+	}
+
+	// DNS records for bootstrap droplet
+	_, err = cloudflare.NewRecord(ctx, "dev-test-bootstrap2-iroh-auth-A", &cloudflare.RecordArgs{
+		ZoneId:  pulumi.String(zoneId),
+		Name:    pulumi.String("dev-test-bootstrap2-iroh-auth"),
+		Type:    pulumi.String("A"),
+		Content: bootstrapDroplet.Ipv4Address,
+		Ttl:     pulumi.Int(300),
+		Proxied: pulumi.Bool(false),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = cloudflare.NewRecord(ctx, "dev-test-bootstrap2-iroh-auth-AAAA", &cloudflare.RecordArgs{
+		ZoneId:  pulumi.String(zoneId),
+		Name:    pulumi.String("dev-test-bootstrap2-iroh-auth"),
+		Type:    pulumi.String("AAAA"),
+		Content: bootstrapDroplet.Ipv6Address,
+		Ttl:     pulumi.Int(300),
+		Proxied: pulumi.Bool(false),
+	})
+	if err != nil {
+		return err
+	}
+
+	// DNS records for auth droplet
+	_, err = cloudflare.NewRecord(ctx, "dev-test-auth-A", &cloudflare.RecordArgs{
+		ZoneId:  pulumi.String(zoneId),
+		Name:    pulumi.String("dev-test-auth"),
+		Type:    pulumi.String("A"),
+		Content: authDroplet.Ipv4Address,
+		Ttl:     pulumi.Int(300),
+		Proxied: pulumi.Bool(false),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = cloudflare.NewRecord(ctx, "dev-test-auth-AAAA", &cloudflare.RecordArgs{
+		ZoneId:  pulumi.String(zoneId),
+		Name:    pulumi.String("dev-test-auth"),
+		Type:    pulumi.String("AAAA"),
+		Content: authDroplet.Ipv6Address,
+		Ttl:     pulumi.Int(300),
+		Proxied: pulumi.Bool(false),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary
- Adds a dev deployment of the authenticated bootstrap/relay service, split across two minimal droplets (S1VCPU2GB) using Podman Quadlets
- Bootstrap server at `dev-test-bootstrap2-iroh-auth.holochain.org`, auth server (hc_auth_server v0.1.5) at `dev-test-auth.holochain.org`
- Uses DO managed Valkey (db-s-1vcpu-1gb) instead of a containerized database
- Cloudflare DNS and certbot TLS provisioning for both machines

## Test plan
- [x] Deployed and verified both services return HTTP 200
- [ ] Verify OAuth login flow works end-to-end
- [ ] Verify bootstrap authentication hook calls auth service successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)