### PR TITLE
feat: add iroh-relay-unyt deployment

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -29,6 +29,14 @@ jobs:
             cat stderr.log | grep "in.*line.*column" -B1 -A1 --no-group-separator | sed -z 's/\([^\n]*\)\n\s*in "\([^"]*\)", line \([[:digit:]]\+\), column \([[:digit:]]\+\):\s*/::error file=dev-test-bootstrap2-iroh\/cloud-init.yaml,title=\1 in \2,line=\3,col=\4::/g'
             exit 1
           fi
+      - name: Lint iroh-relay-unyt cloud-init file
+        run: |
+          if ! cloud-init schema -c iroh-relay-unyt/cloud-init.yaml 2> >(tee stderr.log) >> $GITHUB_STEP_SUMMARY
+          then
+            # Print errors as such in GitHub logs.
+            cat stderr.log | grep "in.*line.*column" -B1 -A1 --no-group-separator | sed -z 's/\([^\n]*\)\n\s*in "\([^"]*\)", line \([[:digit:]]\+\), column \([[:digit:]]\+\):\s*/::error file=iroh-relay-unyt\/cloud-init.yaml,title=\1 in \2,line=\3,col=\4::/g'
+            exit 1
+          fi
       - name: Lint hc-auth-iroh-unyt cloud-init file
         run: |
           if ! cloud-init schema -c hc-auth-iroh-unyt/cloud-init.yaml.tmpl 2> >(tee stderr.log) >> $GITHUB_STEP_SUMMARY

--- a/iroh-relay-hc/cloud-init.yaml
+++ b/iroh-relay-hc/cloud-init.yaml
@@ -12,7 +12,7 @@ write_files:
       https_bind_addr = "[::]:443"
       quic_bind_addr = "[::]:7842"
       cert_mode = "LetsEncrypt"
-      hostname = "iroh-relay-unyt.holochain.org"
+      hostname = "iroh-relay-hc.holochain.org"
       contact = "contact@holochain.org"
       prod_tls = true
       cert_dir = "/var/lib/iroh-relay/certs"

--- a/iroh-relay-unyt/cloud-init.yaml
+++ b/iroh-relay-unyt/cloud-init.yaml
@@ -1,0 +1,70 @@
+#cloud-config
+
+write_files:
+  - content: |
+      enable_relay = true
+      http_bind_addr = "[::]:80"
+      enable_quic_addr_discovery = true
+      enable_metrics = true
+      metrics_bind_addr = "127.0.0.1:9090"
+
+      [tls]
+      https_bind_addr = "[::]:443"
+      quic_bind_addr = "[::]:7842"
+      cert_mode = "LetsEncrypt"
+      hostname = "iroh-relay-unyt.holochain.org"
+      contact = "contact@holochain.org"
+      prod_tls = true
+      cert_dir = "/var/lib/iroh-relay/certs"
+    path: /etc/iroh-relay/config.toml
+    permissions: "0644"
+
+  - content: |
+      [Unit]
+      Description=Iroh Relay Server
+      After=network-online.target
+      Wants=network-online.target
+
+      [Service]
+      Type=simple
+      ExecStart=/usr/local/bin/iroh-relay --config-path /etc/iroh-relay/config.toml
+      Restart=always
+      RestartSec=5
+      Environment=RUST_LOG=info
+      StateDirectory=iroh-relay
+
+      [Install]
+      WantedBy=multi-user.target
+    path: /etc/systemd/system/iroh-relay.service
+    permissions: "0644"
+
+  - content: |
+      #!/bin/bash
+      set -euo pipefail
+
+      # Restart journald so its storage directory matches the machine ID
+      # that cloud-init may have reinitialized.
+      systemctl restart systemd-journald
+
+      apt-get update -y
+      apt-get install -y curl tar
+
+      # Download and install iroh-relay v0.97.0
+      curl -fsSL https://github.com/n0-computer/iroh/releases/download/v0.97.0/iroh-relay-v0.97.0-x86_64-unknown-linux-musl.tar.gz \
+        -o /tmp/iroh-relay.tar.gz
+      echo "4d498f5f959b143c2017a2646dc67e6ac4ef5c11a1170ce6979ad978b3879cc5  /tmp/iroh-relay.tar.gz" | sha256sum -c -
+      tar -xzf /tmp/iroh-relay.tar.gz -C /tmp
+      install -m 0755 /tmp/iroh-relay /usr/local/bin/iroh-relay
+      rm -f /tmp/iroh-relay.tar.gz /tmp/iroh-relay
+
+      # Create state directories
+      mkdir -p /etc/iroh-relay /var/lib/iroh-relay/certs
+
+      # Start the service
+      systemctl daemon-reload
+      systemctl enable --now iroh-relay
+    path: /opt/iroh-relay/provision.sh
+    permissions: "0755"
+
+runcmd:
+  - /opt/iroh-relay/provision.sh

--- a/main.go
+++ b/main.go
@@ -13,6 +13,11 @@ import (
 )
 
 func main() {
+	irohRelayUnytCloudInitYaml, err := os.ReadFile("iroh-relay-unyt/cloud-init.yaml")
+	if err != nil {
+		log.Fatalf("failed to load iroh-relay-unyt/cloud-init.yaml: %s", err)
+	}
+
 	devTestBootstrap2IrohCloudInitYaml, err := os.ReadFile("dev-test-bootstrap2-iroh/cloud-init.yaml")
 	if err != nil {
 		log.Fatalf("failed to load dev-test-bootstrap2-iroh/cloud-init.yaml: %s", err)
@@ -37,6 +42,10 @@ func main() {
 		}
 
 		if err := configureHcAuthIrohUnyt(ctx, hcAuthIrohUnytCloudInitTmpl); err != nil {
+			return err
+		}
+
+		if err := configureIrohRelayUnyt(ctx, string(irohRelayUnytCloudInitYaml)); err != nil {
 			return err
 		}
 
@@ -175,4 +184,59 @@ func configureHcAuthIrohUnyt(ctx *pulumi.Context, cloudInitTmpl *template.Templa
 		UserData: userData,
 	}, pulumi.IgnoreChanges([]string{"sshKeys", "userData"}))
 	return err
+}
+
+func configureIrohRelayUnyt(ctx *pulumi.Context, cloudInitYaml string) error {
+	cfg := pulumiConfig.New(ctx, "dns")
+	zoneId := cfg.Require("cloudflare-zone-id")
+
+	getSshKeysResult, err := digitalocean.GetSshKeys(ctx, &digitalocean.GetSshKeysArgs{}, nil)
+	if err != nil {
+		return err
+	}
+
+	var sshFingerprints []string
+	for _, key := range getSshKeysResult.SshKeys {
+		sshFingerprints = append(sshFingerprints, key.Fingerprint)
+	}
+
+	droplet, err := digitalocean.NewDroplet(ctx, "iroh-relay-unyt", &digitalocean.DropletArgs{
+		Image:    pulumi.String("ubuntu-24-04-x64"),
+		Name:     pulumi.String("iroh-relay-unyt"),
+		Region:   pulumi.String(digitalocean.RegionNYC1),
+		Size:     pulumi.String(digitalocean.DropletSlugDropletS2VCPU2GB),
+		Ipv6:     pulumi.Bool(true),
+		Tags:     pulumi.StringArray{pulumi.String("network-services")},
+		SshKeys:  pulumi.ToStringArray(sshFingerprints),
+		UserData: pulumi.String(cloudInitYaml),
+	}, pulumi.IgnoreChanges([]string{"sshKeys"}))
+	if err != nil {
+		return err
+	}
+
+	_, err = cloudflare.NewRecord(ctx, "iroh-relay-unyt-A", &cloudflare.RecordArgs{
+		ZoneId:  pulumi.String(zoneId),
+		Name:    pulumi.String("iroh-relay-unyt"),
+		Type:    pulumi.String("A"),
+		Content: droplet.Ipv4Address,
+		Ttl:     pulumi.Int(300),
+		Proxied: pulumi.Bool(false),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = cloudflare.NewRecord(ctx, "iroh-relay-unyt-AAAA", &cloudflare.RecordArgs{
+		ZoneId:  pulumi.String(zoneId),
+		Name:    pulumi.String("iroh-relay-unyt"),
+		Type:    pulumi.String("AAAA"),
+		Content: droplet.Ipv6Address,
+		Ttl:     pulumi.Int(300),
+		Proxied: pulumi.Bool(false),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -18,6 +18,11 @@ func main() {
 		log.Fatalf("failed to load iroh-relay-unyt/cloud-init.yaml: %s", err)
 	}
 
+	irohRelayHcCloudInitYaml, err := os.ReadFile("iroh-relay-hc/cloud-init.yaml")
+	if err != nil {
+		log.Fatalf("failed to load iroh-relay-hc/cloud-init.yaml: %s", err)
+	}
+
 	devTestBootstrap2IrohCloudInitYaml, err := os.ReadFile("dev-test-bootstrap2-iroh/cloud-init.yaml")
 	if err != nil {
 		log.Fatalf("failed to load dev-test-bootstrap2-iroh/cloud-init.yaml: %s", err)
@@ -46,6 +51,10 @@ func main() {
 		}
 
 		if err := configureIrohRelayUnyt(ctx, string(irohRelayUnytCloudInitYaml)); err != nil {
+			return err
+		}
+
+		if err := configureIrohRelayHc(ctx, string(irohRelayHcCloudInitYaml)); err != nil {
 			return err
 		}
 
@@ -229,6 +238,61 @@ func configureIrohRelayUnyt(ctx *pulumi.Context, cloudInitYaml string) error {
 	_, err = cloudflare.NewRecord(ctx, "iroh-relay-unyt-AAAA", &cloudflare.RecordArgs{
 		ZoneId:  pulumi.String(zoneId),
 		Name:    pulumi.String("iroh-relay-unyt"),
+		Type:    pulumi.String("AAAA"),
+		Content: droplet.Ipv6Address,
+		Ttl:     pulumi.Int(300),
+		Proxied: pulumi.Bool(false),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func configureIrohRelayHc(ctx *pulumi.Context, cloudInitYaml string) error {
+	cfg := pulumiConfig.New(ctx, "dns")
+	zoneId := cfg.Require("cloudflare-zone-id")
+
+	getSshKeysResult, err := digitalocean.GetSshKeys(ctx, &digitalocean.GetSshKeysArgs{}, nil)
+	if err != nil {
+		return err
+	}
+
+	var sshFingerprints []string
+	for _, key := range getSshKeysResult.SshKeys {
+		sshFingerprints = append(sshFingerprints, key.Fingerprint)
+	}
+
+	droplet, err := digitalocean.NewDroplet(ctx, "iroh-relay-hc", &digitalocean.DropletArgs{
+		Image:    pulumi.String("ubuntu-24-04-x64"),
+		Name:     pulumi.String("iroh-relay-hc"),
+		Region:   pulumi.String(digitalocean.RegionNYC1),
+		Size:     pulumi.String(digitalocean.DropletSlugDropletS2VCPU2GB),
+		Ipv6:     pulumi.Bool(true),
+		Tags:     pulumi.StringArray{pulumi.String("network-services")},
+		SshKeys:  pulumi.ToStringArray(sshFingerprints),
+		UserData: pulumi.String(cloudInitYaml),
+	}, pulumi.IgnoreChanges([]string{"sshKeys"}))
+	if err != nil {
+		return err
+	}
+
+	_, err = cloudflare.NewRecord(ctx, "iroh-relay-hc-A", &cloudflare.RecordArgs{
+		ZoneId:  pulumi.String(zoneId),
+		Name:    pulumi.String("iroh-relay-hc"),
+		Type:    pulumi.String("A"),
+		Content: droplet.Ipv4Address,
+		Ttl:     pulumi.Int(300),
+		Proxied: pulumi.Bool(false),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = cloudflare.NewRecord(ctx, "iroh-relay-hc-AAAA", &cloudflare.RecordArgs{
+		ZoneId:  pulumi.String(zoneId),
+		Name:    pulumi.String("iroh-relay-hc"),
 		Type:    pulumi.String("AAAA"),
 		Content: droplet.Ipv6Address,
 		Ttl:     pulumi.Int(300),

--- a/main.go
+++ b/main.go
@@ -210,14 +210,15 @@ func configureIrohRelayUnyt(ctx *pulumi.Context, cloudInitYaml string) error {
 	}
 
 	droplet, err := digitalocean.NewDroplet(ctx, "iroh-relay-unyt", &digitalocean.DropletArgs{
-		Image:    pulumi.String("ubuntu-24-04-x64"),
-		Name:     pulumi.String("iroh-relay-unyt"),
-		Region:   pulumi.String(digitalocean.RegionNYC1),
-		Size:     pulumi.String(digitalocean.DropletSlugDropletS2VCPU2GB),
-		Ipv6:     pulumi.Bool(true),
-		Tags:     pulumi.StringArray{pulumi.String("network-services")},
-		SshKeys:  pulumi.ToStringArray(sshFingerprints),
-		UserData: pulumi.String(cloudInitYaml),
+		Image:      pulumi.String("ubuntu-24-04-x64"),
+		Name:       pulumi.String("iroh-relay-unyt"),
+		Region:     pulumi.String(digitalocean.RegionNYC1),
+		Size:       pulumi.String(digitalocean.DropletSlugDropletS2VCPU2GB),
+		Ipv6:       pulumi.Bool(true),
+		Monitoring: pulumi.Bool(true),
+		Tags:       pulumi.StringArray{pulumi.String("network-services")},
+		SshKeys:    pulumi.ToStringArray(sshFingerprints),
+		UserData:   pulumi.String(cloudInitYaml),
 	}, pulumi.IgnoreChanges([]string{"sshKeys"}))
 	if err != nil {
 		return err
@@ -265,14 +266,15 @@ func configureIrohRelayHc(ctx *pulumi.Context, cloudInitYaml string) error {
 	}
 
 	droplet, err := digitalocean.NewDroplet(ctx, "iroh-relay-hc", &digitalocean.DropletArgs{
-		Image:    pulumi.String("ubuntu-24-04-x64"),
-		Name:     pulumi.String("iroh-relay-hc"),
-		Region:   pulumi.String(digitalocean.RegionNYC1),
-		Size:     pulumi.String(digitalocean.DropletSlugDropletS2VCPU2GB),
-		Ipv6:     pulumi.Bool(true),
-		Tags:     pulumi.StringArray{pulumi.String("network-services")},
-		SshKeys:  pulumi.ToStringArray(sshFingerprints),
-		UserData: pulumi.String(cloudInitYaml),
+		Image:      pulumi.String("ubuntu-24-04-x64"),
+		Name:       pulumi.String("iroh-relay-hc"),
+		Region:     pulumi.String(digitalocean.RegionNYC1),
+		Size:       pulumi.String(digitalocean.DropletSlugDropletS2VCPU2GB),
+		Ipv6:       pulumi.Bool(true),
+		Monitoring: pulumi.Bool(true),
+		Tags:       pulumi.StringArray{pulumi.String("network-services")},
+		SshKeys:    pulumi.ToStringArray(sshFingerprints),
+		UserData:   pulumi.String(cloudInitYaml),
 	}, pulumi.IgnoreChanges([]string{"sshKeys"}))
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- Deploy a standalone Iroh relay server (v0.95.1) for the Unyt project at `iroh-relay-unyt.holochain.org`
- DigitalOcean droplet (s-2vcpu-2gb) in NYC1 with Cloudflare A/AAAA DNS records
- Uses the upstream `iroh-relay` musl binary directly via a native systemd service (no containers)
- Built-in Let's Encrypt TLS, QUIC address discovery on port 7842, metrics on port 9090
- Open access (no auth restriction)
- CI lint step added for the new cloud-init file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI cloud-init schema validation that surfaces failures as annotated errors in pull requests.
* **New Features**
  * End-to-end provisioning for iroh-relay instances: automated VM provisioning, cloud-init-based installation and service setup, TLS certificate issuance, metrics exposure, and automatic IPv4/IPv6 DNS records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->